### PR TITLE
fixed NoClassDefFoundError of X11FontManager

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,8 +9,11 @@ FROM openjdk:8-jre-slim
 
 EXPOSE 8080
 
+RUN apt-get update; apt-get install -y fontconfig libfreetype6 
+
 RUN mkdir /app
 
 COPY --from=build /home/gradle/src/burning-okr-app/build/libs/*.jar /app/burning-okr.jar
+
 
 ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/app/burning-okr.jar"]

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "skipLibCheck": true,
     "baseUrl": "./",
     "downlevelIteration": true,
     "module": "esnext",
@@ -14,7 +15,7 @@
     "target": "es2015",
     "resolveJsonModule": true,
     "plugins": [
-      { "name": "tslint-language-service"}
+      { "name": "tslint-language-service" }
     ],
     "typeRoots": [
       "node_modules/@types"


### PR DESCRIPTION
We were able to reproduce the error.

It is because we are using the jdk8-slim image in the backend Dockerfile. The slim images don't seem to bring the class anymore.
However, you can easily reinstall it using the following command.
in the backend/Dockerfile

RUN apt-get update; apt-get install -y fontconfig libfreetype6

https://stackoverflow.com/questions/55454036/noclassdeffounderror-could-not-initialize-class-sun-awt-x11fontmanager