### PR TITLE
Fix topic draft delete with comments

### DIFF
--- a/backend/burning-okr/burning-okr-app/src/main/java/org/burningokr/controller/okr/ObjectiveController.java
+++ b/backend/burning-okr/burning-okr-app/src/main/java/org/burningokr/controller/okr/ObjectiveController.java
@@ -50,10 +50,7 @@ public class ObjectiveController {
       ObjectiveService objectiveService,
       DataMapper<Objective, ObjectiveDto> objectiveMapper,
       DataMapper<KeyResult, KeyResultDto> keyResultMapper,
-      DataMapper<NoteObjective, NoteObjectiveDto>
-          noteObjectiveMapper, // IS NEEDED BUT CRASHES ON STARTUP FOR SOME REASON?
-      // Creates following error: Says to create a Bean out of DataMapper Interface?!
-      // TODO P.B. 22.07.2021: FIX ERROR
+      DataMapper<NoteObjective, NoteObjectiveDto> noteObjectiveMapper,
       AuthorizationService authorizationService) {
     this.objectiveService = objectiveService;
     this.objectiveMapper = objectiveMapper;

--- a/backend/burning-okr/burning-okr-model/src/main/java/org/burningokr/model/okr/okrTopicDraft/OkrTopicDraft.java
+++ b/backend/burning-okr/burning-okr-model/src/main/java/org/burningokr/model/okr/okrTopicDraft/OkrTopicDraft.java
@@ -1,8 +1,12 @@
 package org.burningokr.model.okr.okrTopicDraft;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import javax.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.burningokr.model.okr.NoteTopicDraft;
 import org.burningokr.model.okr.OkrTopicDescription;
 import org.burningokr.model.okr.histories.OkrTopicDraftHistory;
 import org.burningokr.model.okrUnits.OkrUnit;
@@ -18,4 +22,8 @@ public class OkrTopicDraft extends OkrTopicDescription {
 
   @Enumerated(EnumType.STRING)
   private OkrTopicDraftStatusEnum currentStatus;
+
+  @ToString.Exclude
+  @OneToMany(mappedBy = "parentTopicDraft", cascade = CascadeType.REMOVE)
+  private Collection<NoteTopicDraft> notes = new ArrayList<>();
 }


### PR DESCRIPTION
TopicDrafts containing comments can now be deleted. The comments belonging to the deleted topicdraft are also deleted.
Also deleted comment and ran SpotlessApply.