### PR TITLE
fix(Application.yaml): Fixed SQL Dialect for Staging and Prod from Postgres to MSSQL

### DIFF
--- a/backend/burning-okr/burning-okr-app/src/main/resources/application.yaml
+++ b/backend/burning-okr/burning-okr-app/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
       ddl-auto: none
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+        dialect: org.burningokr.dialects.SQLServer2012UUIDFixDialect
         format_sql: true
         globally_quoted_identifiers: true
   flyway:

--- a/frontend/src/app/core/version-form/version-form.component.ts
+++ b/frontend/src/app/core/version-form/version-form.component.ts
@@ -11,6 +11,12 @@ import { ChangeLog } from '../../shared/model/ui/change-log';
 export class VersionFormComponent {
   versionChanges: ChangeLog[] = [
     {
+      version: '1.3.9 (05.10.2021',
+      changes: [
+          'Fixed serious bug with the SQL-Server'
+      ]
+    },
+    {
       version: '1.3.8 (07.09.2021)',
       changes: [
           'Added more logging'

--- a/frontend/src/app/core/version-form/version-form.component.ts
+++ b/frontend/src/app/core/version-form/version-form.component.ts
@@ -11,7 +11,7 @@ import { ChangeLog } from '../../shared/model/ui/change-log';
 export class VersionFormComponent {
   versionChanges: ChangeLog[] = [
     {
-      version: '1.3.9 (05.10.2021',
+      version: '1.3.9 (05.10.2021)',
       changes: [
           'Fixed serious bug with the SQL-Server'
       ]

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,3 @@
-1.3.8
+1.3.9
 
-- Added more logging
+- Fixed serious bug with the SQL-Server


### PR DESCRIPTION
The default sql dialect for staging and prod was the Postgres dialect. We are using MSSQL Server for those backends which is probably the reason why it crashed