### PR TITLE
fix(Task-State Migration): Added sql-server migration script to fix task-states

### DIFF
--- a/backend/burning-okr/burning-okr-app/src/main/resources/db/migration/sqlserver/V13__TaskStateFix.sql
+++ b/backend/burning-okr/burning-okr-app/src/main/resources/db/migration/sqlserver/V13__TaskStateFix.sql
@@ -1,0 +1,31 @@
+-- Add new column
+ALTER TABLE dbo.task_state ADD id_temp bigint;
+GO
+
+BEGIN TRANSACTION
+-- Drop PKEY/FKEY Constraints
+ALTER TABLE dbo.task DROP CONSTRAINT task_task_state_fkey;
+ALTER TABLE dbo.task_state DROP CONSTRAINT task_state_pkey;
+
+
+
+-- Copy Data
+UPDATE dbo.task_state SET id_temp = id;
+
+
+-- Drop old column
+ALTER TABLE dbo.task_state DROP COLUMN id;
+
+
+-- Rename new column to old column
+EXEC sp_rename 'task_state.id_temp', 'id', 'COLUMN';
+
+
+-- Re-Add Constraints
+ALTER TABLE dbo.task_state ALTER COLUMN id bigint NOT NULL
+ALTER TABLE dbo.task_state ADD CONSTRAINT task_state_pkey PRIMARY KEY (id);
+
+ALTER TABLE dbo.task ADD CONSTRAINT task_task_state_fkey FOREIGN key (task_state_id)
+    REFERENCES task_state(id)
+    ON UPDATE NO ACTION ON DELETE NO ACTION;
+COMMIT

--- a/frontend/src/app/core/version-form/version-form.component.ts
+++ b/frontend/src/app/core/version-form/version-form.component.ts
@@ -11,6 +11,12 @@ import { ChangeLog } from '../../shared/model/ui/change-log';
 export class VersionFormComponent {
   versionChanges: ChangeLog[] = [
     {
+      version: '1.3.10 (06.10.2021)',
+      changes: [
+          'Fixed a bug regarding the task board'
+      ]
+    },
+    {
       version: '1.3.9 (05.10.2021)',
       changes: [
           'Fixed serious bug with the SQL-Server'

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,3 @@
-1.3.9
+1.3.10
 
-- Fixed serious bug with the SQL-Server
+- Fixed a bug regarding the task board


### PR DESCRIPTION
The id column in the task-state table had an identity property which clashed with our backend when it comes to ID generation