### PR TITLE
fix(dashboard): possible fix for chart mapping error on staging.

### DIFF
--- a/frontend/src/app/dashboard/chart-renderer/chart-renderer.component.ts
+++ b/frontend/src/app/dashboard/chart-renderer/chart-renderer.component.ts
@@ -45,5 +45,4 @@ export class ChartRendererComponent implements OnInit {
       );
     componentRef.instance.chartOptions = this.chartOptions;
   }
-
 }

--- a/frontend/src/app/dashboard/chart-renderer/chart-renderer.component.ts
+++ b/frontend/src/app/dashboard/chart-renderer/chart-renderer.component.ts
@@ -27,12 +27,12 @@ export class ChartRendererComponent implements OnInit {
 
   ngOnInit(): void {
     const componentType: ConstructorType<BaseChartOptions> = chartComponentMappings.find(
-      mapping => mapping.chartOptionsType === this.chartOptions.constructor,
+      mapping => mapping.chartOptionsType.name === this.chartOptions.chartOptionsName,
     )?.componentType;
 
     if (!componentType) {
       throw new Error(
-        `No Mapping from chartOptions ${this.chartOptions.constructor.name}
+        `No Mapping from chartOptions ${this.chartOptions.chartOptionsName}
         to ComponentType found. Did you add the Decorator to the ChartComponent?`,
       );
     }

--- a/frontend/src/app/dashboard/chart-renderer/chart-renderer.component.ts
+++ b/frontend/src/app/dashboard/chart-renderer/chart-renderer.component.ts
@@ -45,4 +45,5 @@ export class ChartRendererComponent implements OnInit {
       );
     componentRef.instance.chartOptions = this.chartOptions;
   }
+
 }

--- a/frontend/src/app/dashboard/charts/basic-line-chart/basic-line-chart.component.ts
+++ b/frontend/src/app/dashboard/charts/basic-line-chart/basic-line-chart.component.ts
@@ -3,11 +3,11 @@ import { LineChartOptions } from '../../model/ui/line-chart-options';
 import { CustomChartComponent } from '../../decorator/chart-component.decorator';
 import { BaseChartComponent } from '../base-chart/base-chart.component';
 
-@CustomChartComponent(LineChartOptions)
 @Component({
   selector: 'app-basic-line-chart',
   templateUrl: './basic-line-chart.component.html',
   styleUrls: ['./basic-line-chart.component.scss'],
 })
+@CustomChartComponent(LineChartOptions)
 export class BasicLineChartComponent extends BaseChartComponent<LineChartOptions> {
 }

--- a/frontend/src/app/dashboard/charts/pie-chart/pie-chart.component.ts
+++ b/frontend/src/app/dashboard/charts/pie-chart/pie-chart.component.ts
@@ -3,11 +3,11 @@ import { PieChartOptions } from '../../model/ui/pie-chart-options';
 import { CustomChartComponent } from '../../decorator/chart-component.decorator';
 import { BaseChartComponent } from '../base-chart/base-chart.component';
 
-@CustomChartComponent(PieChartOptions)
 @Component({
   selector: 'app-pie-chart',
   templateUrl: './pie-chart.component.html',
   styleUrls: ['./pie-chart.component.scss'],
 })
+@CustomChartComponent(PieChartOptions)
 export class PieChartComponent extends BaseChartComponent<PieChartOptions> {
 }

--- a/frontend/src/app/dashboard/model/ui/base-chart-options.ts
+++ b/frontend/src/app/dashboard/model/ui/base-chart-options.ts
@@ -13,4 +13,5 @@ export abstract class BaseChartOptions {
   chartType: ChartInformationTypeEnum;
   selectedTeamIds?: number[];
   colors = ['#b81f40', '#d1b37b', '#e7795c', '#48b69c', '#479fc0', '#6c548b', '#575756', '#b2b2b2', '#a3bbc8'];
+  chartOptionsName: string = '';
 }

--- a/frontend/src/app/dashboard/model/ui/line-chart-options.ts
+++ b/frontend/src/app/dashboard/model/ui/line-chart-options.ts
@@ -10,5 +10,6 @@ export class LineChartOptions extends BaseChartOptions {
   options: ApexOptions;
   chartType: ChartInformationTypeEnum = ChartInformationTypeEnum.LINE_PROGRESS;
   selectedTeamIds: number[] = [];
+  chartOptionsName: string = 'LineChartOptions';
 }
 

--- a/frontend/src/app/dashboard/model/ui/pie-chart-options.ts
+++ b/frontend/src/app/dashboard/model/ui/pie-chart-options.ts
@@ -11,4 +11,5 @@ export class PieChartOptions extends BaseChartOptions {
     align: 'left',
   };
   chartType: ChartInformationTypeEnum = ChartInformationTypeEnum.PIE_TOPICDRAFTOVERVIEW;
+  chartOptionsName: string = 'PieChartOptions';
 }

--- a/frontend/src/app/dashboard/services/chart.mapper.service.spec.ts
+++ b/frontend/src/app/dashboard/services/chart.mapper.service.spec.ts
@@ -26,6 +26,7 @@ describe('ChartMapperService', () => {
       chartType: ChartInformationTypeEnum.LINE_PROGRESS,
       selectedTeamIds: [],
       colors: [],
+      chartOptionsName: '',
 
     };
 
@@ -49,6 +50,7 @@ describe('ChartMapperService', () => {
       chartType: ChartInformationTypeEnum.PIE_TOPICDRAFTOVERVIEW,
       selectedTeamIds: [],
       colors: [],
+      chartOptionsName: '',
 
     };
 


### PR DESCRIPTION
Constructor was used in mapping inside the onInit of chart-renderer.component.
Constructor name is probably different after compilation. Replaced usage of constructor. This should fix it. (Has to be tested on staging)